### PR TITLE
Make the optional psconfig remote add option indeed optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following variables can/should be defined for your host setup:
   - `perfsonar_ntp_servers` is a list of NTP servers to configure on the perfSONAR testpoint, or an empty list, per default, if you want to use the perfSONAR provided NTP servers.
   - `perfsonar_disable_root_ssh` disable or keep ssh root access, the default is to disable it.
   - `perfsonar_psconfig_remote_remotes` list the URL of remote templates that should be added or deleted from each testpoint host.
-  - `perfsonar_psconfig_remote_options` contains the options to add to the `psconfig remote add` command.
+     - provides the option to include options to the `psconfig remote add` command.
 
   - Some other variables are defined at the end of `default/main.yml` and in `vars/Debian.yml` and `vars/RedHat.yml` (those contains distro specific settings), but shouldn't need to be altered for a regular install.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,14 +37,14 @@ perfsonar_disable_root_ssh: True
 # psconfig related setup
 # A list of remotes you want to use on your perfsonar-testpoint node
 # Each item in the list must contain the remote URL and its state ('present' or 'absent')
+# If we want to add any archives coming from the remote template the optional opt: '--configure-archives', should be added
 # Example:
 # perfsonar_psconfig_remote_remotes:
 #   - { url: 'https://central.perfsonar.utr.surfcloud.nl/psconfig/astron-mesh.json', state: 'present' }
+#   - { url: 'https://central.perfsonar.utr.surfcloud.nl/psconfig/astron-mesh.json', opt: '--configure-archives', state: 'present' }
 #   - { url: 'https://central.astron.pert.edu/psconfig/astron-mesh.json', state: 'absent' }
 # If the list is empty or the variable undefined, no remote will be added nor removed.
 perfsonar_psconfig_remote_remotes: []
-# We usually want to add any archives coming from the remote template
-perfsonar_psconfig_remote_options: "--configure-archives"
 
 # setting the perfsonar_archive-* variables will register testpoints with the archivers
 perfsonar_archive_auth_interfaces: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
   tags: [ 'ps::config', 'ps::running' ]
   command: >
     psconfig remote add
-    "{{ perfsonar_psconfig_remote_options }}" "{{ item.url }}"
+    "{{ item.opt }}" "{{ item.url }}"
   when: item.state == 'present'
   with_items: "{{ perfsonar_psconfig_remote_remotes | default([]) }}"
 


### PR DESCRIPTION
IMHO the option of '--configure-archives' should be applied per mesh url/config and for all meshes.
the implemented functionality, kind of changes the original implementation of psconfig

IMHO copy pasting the `opt` parameter is not that much of a hassle