### PR TITLE
Make the psconfig remote add smarter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,8 @@
   tags: [ 'ps::config', 'ps::running' ]
   command: >
     psconfig remote add
-    "{{ item.opt }}" "{{ item.url }}"
+    {{ [item.opt | default([])] | flatten | join(' ') }}
+    "{{ item.url }}"
   when: item.state == 'present'
   with_items: "{{ perfsonar_psconfig_remote_remotes | default([]) }}"
 


### PR DESCRIPTION
It should be possible to skip the opt parameter completely
or specify one or more values:

  perfsonar_psconfig_remote_remotes:
    - { url: 'http://...', state: 'present' }
    - { url: 'http://...', opt: '--quiet', state: 'present' }
    - { url: 'http://...', opt: ['--quiet', '--configure-archives'], state: 'present' }