### PR TITLE
Added template managed psconfig json for testing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,14 @@
   tags: [ 'ps::config' ]
   include: lsregistration.yml
 
+- name: Define psconfig remotes
+  tags: [ 'ps::config', 'ps::running' ]
+  template:
+    src=pscfg-remotes.j2
+    dest=/etc/perfsonar/psconfig/pscheduler-agent.json.new
+  with_items: "{{ perfsonar_psconfig_remote_remotes | default([]) }}"
+  when: item.state == 'present'
+
 - name: add/delete remote mesh configurations that have a valid URL and state
   tags: [ 'ps::config' ]
   include_tasks: psconfig_remotes.yml

--- a/templates/pscfg-remotes.j2
+++ b/templates/pscfg-remotes.j2
@@ -1,0 +1,20 @@
+{
+   "remotes" : [
+{%
+  set comma = '' %}
+{%
+  for rem in ( perfsonar_psconfig_remote_remotes | default([]) ) %}
+{{comma}}
+      {
+{%
+    set comma = ',' %}
+{%
+    if rem.opt is defined and rem.opt == '--configure-archives' %}
+         "configure-archives" : true,
+{%  endif %}
+         "url" : "{{ rem.url }}"
+      }{%
+  endfor %}
+
+   ]
+}


### PR DESCRIPTION
Changes are applied in /etc/perfsonar/psconfig/pscheduler-agent.json.new

benefits:
Does not apply unnecessary changes to psconfig on Ansible runs

drawback:
It exclusively manages the psconfig remotes json file, which will discard any manual configuration

TODO:
- can be devised to support manual configuration changes
- list item param "state" is becoming useless
- list item param "opt" can be renamed to "archive" as boolean: true/false