### PR TITLE
Displaying system information as part of checking the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Some tags are used in the role, they are meant to run only or skip part of the p
   - `ps::install` : only install perfSONAR packages and their dependencies
   - `ps::config` : only configure any already installed perfSONAR package
   - `ps::running` : checks that your perfSONAR node is running as intended
+  - `ps::monitor` : print some system info of your perfSONAR node
 
 Examples,
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,10 @@
 #####
 # Make sure services are running, but first flush handlers to ensure services are restarted
 - meta: flush_handlers
+- pause:
+    prompt: "Waiting 15 seconds for services to stabilise"
+    seconds: 15
+  tags: [ 'ps::running' ]
 - name: Check that all perfSONAR services are running
   tags: [ 'ps::running' ]
   service:
@@ -83,6 +87,26 @@
 # Run a few useful perfSONAR commands
 # TODO: How to handle errors gracefully?
 # i.e.: report the error, but do not stop playbook execution
+- name: Collecting uptime information
+  tags: [ 'ps::running' ]
+  shell: uptime
+  register: uptime
+  changed_when: False
+- name: Get pscheduler version
+  tags: [ 'ps::running' ]
+  shell: pscheduler version | grep pscheduler-server
+  register: pscheduler_version
+  changed_when: False
+- name: Report system information
+  vars:
+    msg: |
+      {{ansible_fqdn}} - {{uptime.stdout}}
+      {{ansible_distribution}}-{{ansible_distribution_major_version}} - {{ansible_processor_cores}} cores - kernel {{ansible_kernel}}
+      Memory (free/total in MB): {{ansible_memfree_mb}}/{{ansible_memtotal_mb}} (Swap: {{ansible_swapfree_mb}}/{{ansible_swaptotal_mb}})
+      Running {{pscheduler_version.stdout}}
+  debug:
+    msg:
+      - "{{ msg[:-1].split('\n') + (df.stdout_lines | default([])) }}"
 - name: Run pscheduler troubleshoot locally
   tags: [ 'ps::running' ]
   command: pscheduler troubleshoot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,10 +71,12 @@
 #####
 # Make sure services are running, but first flush handlers to ensure services are restarted
 - meta: flush_handlers
+
 - pause:
-    prompt: "Waiting 15 seconds for services to stabilise"
-    seconds: 15
+    prompt: "Waiting 12 seconds for services to stabilise"
+    seconds: 12
   tags: [ 'ps::running' ]
+
 - name: Check that all perfSONAR services are running
   tags: [ 'ps::running' ]
   service:
@@ -92,12 +94,15 @@
   shell: uptime
   register: uptime
   changed_when: False
+
 - name: Get pscheduler version
-  tags: [ 'ps::running' ]
+  tags: [ 'ps::running', 'ps::monitor' ]
   shell: pscheduler version | grep pscheduler-server
   register: pscheduler_version
   changed_when: False
+
 - name: Report system information
+  tags: [ 'ps::running', 'ps::monitor' ]
   vars:
     msg: |
       {{ansible_fqdn}} - {{uptime.stdout}}
@@ -106,9 +111,20 @@
       Running {{pscheduler_version.stdout}}
   debug:
     msg:
-      - "{{ msg[:-1].split('\n') + (df.stdout_lines | default([])) }}"
+      - "{{ msg[:-1].split('\n') }}"
+
 - name: Run pscheduler troubleshoot locally
   tags: [ 'ps::running' ]
   command: pscheduler troubleshoot
+  register: pscheduler_troubleshoot
+  until: pscheduler_troubleshoot is succeeded
+  retries: 3
   changed_when: False
+
+- name: Output pscheduler troubleshoot
+  tags: [ 'ps::running', 'ps::monitor' ]
+  debug:
+    msg:
+      - "{{ pscheduler_troubleshoot.stdout.split('\n') }}"
+  when: pscheduler_troubleshoot is defined
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,9 +90,15 @@
 # TODO: How to handle errors gracefully?
 # i.e.: report the error, but do not stop playbook execution
 - name: Collecting uptime information
-  tags: [ 'ps::running' ]
+  tags: [ 'ps::running', 'ps::monitor' ]
   shell: uptime
   register: uptime
+  changed_when: False
+
+- name: Get perfSONAR bundle type and version
+  tags: [ 'ps::running', 'ps::monitor' ]
+  shell: cat /var/lib/perfsonar/bundles/bundle_type /var/lib/perfsonar/bundles/bundle_version
+  register: perfsonar_bundle_version
   changed_when: False
 
 - name: Get pscheduler version
@@ -109,6 +115,7 @@
       {{ansible_distribution}}-{{ansible_distribution_major_version}} - {{ansible_processor_cores}} cores - kernel {{ansible_kernel}}
       Memory (free/total in MB): {{ansible_memfree_mb}}/{{ansible_memtotal_mb}} (Swap: {{ansible_swapfree_mb}}/{{ansible_swaptotal_mb}})
       Running {{pscheduler_version.stdout}}
+      From {{ perfsonar_bundle_version.stdout_lines | join (' bundle - version ') }}
   debug:
     msg:
       - "{{ msg[:-1].split('\n') }}"
@@ -121,10 +128,10 @@
   retries: 3
   changed_when: False
 
-- name: Output pscheduler troubleshoot
+- name: Report pscheduler troubleshoot output
   tags: [ 'ps::running', 'ps::monitor' ]
   debug:
     msg:
-      - "{{ pscheduler_troubleshoot.stdout.split('\n') }}"
+      - "{{ pscheduler_troubleshoot.stdout.replace('\n\n','\n').split('\n') }}"
   when: pscheduler_troubleshoot is defined
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,40 +86,12 @@
       - "{{ perfsonar_services }}"
       - "{{ perfsonar_os_specific_services }}"
 
-# Run a few useful perfSONAR commands
-# TODO: How to handle errors gracefully?
-# i.e.: report the error, but do not stop playbook execution
-- name: Collecting uptime information
+# Get some useful info out of the system
+- name: Check system status
   tags: [ 'ps::running', 'ps::monitor' ]
-  shell: uptime
-  register: uptime
-  changed_when: False
+  include: sysinfo.yml
 
-- name: Get perfSONAR bundle type and version
-  tags: [ 'ps::running', 'ps::monitor' ]
-  shell: cat /var/lib/perfsonar/bundles/bundle_type /var/lib/perfsonar/bundles/bundle_version
-  register: perfsonar_bundle_version
-  changed_when: False
-
-- name: Get pscheduler version
-  tags: [ 'ps::running', 'ps::monitor' ]
-  shell: pscheduler version | grep pscheduler-server
-  register: pscheduler_version
-  changed_when: False
-
-- name: Report system information
-  tags: [ 'ps::running', 'ps::monitor' ]
-  vars:
-    msg: |
-      {{ansible_fqdn}} - {{uptime.stdout}}
-      {{ansible_distribution}}-{{ansible_distribution_major_version}} - {{ansible_processor_cores}} cores - kernel {{ansible_kernel}}
-      Memory (free/total in MB): {{ansible_memfree_mb}}/{{ansible_memtotal_mb}} (Swap: {{ansible_swapfree_mb}}/{{ansible_swaptotal_mb}})
-      Running {{pscheduler_version.stdout}}
-      From {{ perfsonar_bundle_version.stdout_lines | join (' bundle - version ') }}
-  debug:
-    msg:
-      - "{{ msg[:-1].split('\n') }}"
-
+# Run pscheduler troubleshoot
 - name: Run pscheduler troubleshoot locally
   tags: [ 'ps::running' ]
   command: pscheduler troubleshoot

--- a/tasks/sysinfo.yml
+++ b/tasks/sysinfo.yml
@@ -1,0 +1,31 @@
+---
+# Run a few useful perfSONAR commands
+# TODO: How to handle errors gracefully?
+# i.e.: report the error, but do not stop playbook execution
+- name: Collecting uptime information
+  shell: uptime
+  register: uptime
+  changed_when: False
+
+- name: Get perfSONAR bundle type and version
+  shell: cat /var/lib/perfsonar/bundles/bundle_type /var/lib/perfsonar/bundles/bundle_version
+  register: perfsonar_bundle_version
+  changed_when: False
+
+- name: Get pscheduler version
+  shell: pscheduler version | grep pscheduler-server
+  register: pscheduler_version
+  changed_when: False
+
+- name: Report system information
+  vars:
+    msg: |
+      {{ansible_fqdn}} - {{uptime.stdout}}
+      {{ansible_distribution}}-{{ansible_distribution_major_version}} - {{ansible_processor_cores}} cores - kernel {{ansible_kernel}}
+      Memory (free/total in MB): {{ansible_memfree_mb}}/{{ansible_memtotal_mb}} (Swap: {{ansible_swapfree_mb}}/{{ansible_swaptotal_mb}})
+      Running {{pscheduler_version.stdout}}
+      From {{ perfsonar_bundle_version.stdout_lines | join (' bundle - version ') }}
+  debug:
+    msg:
+      - "{{ msg[:-1].split('\n') }}"
+

--- a/tasks/sysinfo.yml
+++ b/tasks/sysinfo.yml
@@ -6,21 +6,25 @@
   shell: uptime
   register: uptime
   changed_when: False
+  ignore_errors: yes
 
 - name: Get perfSONAR bundle type and version
   shell: cat /var/lib/perfsonar/bundles/bundle_type /var/lib/perfsonar/bundles/bundle_version
   register: perfsonar_bundle_version
   changed_when: False
+  ignore_errors: yes
 
 - name: Get pscheduler version
   shell: pscheduler version | grep pscheduler-server
   register: pscheduler_version
   changed_when: False
+  ignore_errors: yes
 
 - name: Get psconfig managed tasks
   shell: psconfig pscheduler-stats | grep "Total tasks managed by agent:"
   register: psconfig_managed_tasks
   changed_when: False
+  ignore_errors: yes
 
 - name: Report system information
   vars:

--- a/tasks/sysinfo.yml
+++ b/tasks/sysinfo.yml
@@ -17,6 +17,11 @@
   register: pscheduler_version
   changed_when: False
 
+- name: Get psconfig managed tasks
+  shell: psconfig pscheduler-stats | grep "Total tasks managed by agent:"
+  register: psconfig_managed_tasks
+  changed_when: False
+
 - name: Report system information
   vars:
     msg: |
@@ -25,6 +30,7 @@
       Memory (free/total in MB): {{ansible_memfree_mb}}/{{ansible_memtotal_mb}} (Swap: {{ansible_swapfree_mb}}/{{ansible_swaptotal_mb}})
       Running {{pscheduler_version.stdout}}
       From {{ perfsonar_bundle_version.stdout_lines | join (' bundle - version ') }}
+      pSConfig {{psconfig_managed_tasks.stdout}}
   debug:
     msg:
       - "{{ msg[:-1].split('\n') }}"

--- a/tasks/sysinfo.yml
+++ b/tasks/sysinfo.yml
@@ -6,25 +6,25 @@
   shell: uptime
   register: uptime
   changed_when: False
-  ignore_errors: yes
+  ignore_errors: True
 
 - name: Get perfSONAR bundle type and version
   shell: cat /var/lib/perfsonar/bundles/bundle_type /var/lib/perfsonar/bundles/bundle_version
   register: perfsonar_bundle_version
   changed_when: False
-  ignore_errors: yes
+  ignore_errors: True
 
 - name: Get pscheduler version
   shell: pscheduler version | grep pscheduler-server
   register: pscheduler_version
   changed_when: False
-  ignore_errors: yes
+  ignore_errors: True
 
 - name: Get psconfig managed tasks
   shell: psconfig pscheduler-stats | grep "Total tasks managed by agent:"
   register: psconfig_managed_tasks
   changed_when: False
-  ignore_errors: yes
+  ignore_errors: True
 
 - name: Report system information
   vars:


### PR DESCRIPTION
Helps to make sure the host is fine when running `pscheduler troubleshoot`.

Also, wait 15 secs before running troubleshoot so that services have a bit of time to stabilise if they were just restarted the moment before.