### PR TITLE
Looking at existing psconfig remotes before adding or deleting.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,18 @@
   tags: [ 'ps::config' ]
   include: lsregistration.yml
 
+- name: Look at current psconfig remote list
+  tags: [ 'ps::config' ]
+  shell: psconfig remote list | tail -n +2 | jq -r .[].url
+  register: psconfig_remotes
+  changed_when: False
+
+- name: Look at current psconfig remote list with configured archives
+  tags: [ 'ps::config' ]
+  shell: psconfig remote list | tail -n +2 | jq -r '.[] | select(."configure-archives"==true) | .url'
+  register: psconfig_remotes_archives
+  changed_when: False
+
 - name: add/delete remote mesh configurations that have a valid URL and state
   tags: [ 'ps::config' ]
   include_tasks: psconfig_remotes.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,18 +51,22 @@
   tags: [ 'ps::config' ]
   include: lsregistration.yml
 
+# pSConfig remotes management
+# We first get a list of configured remotes
 - name: Look at current psconfig remote list
   tags: [ 'ps::config' ]
   shell: psconfig remote list | tail -n +2 | jq -r .[].url
   register: psconfig_remotes
   changed_when: False
 
+# And list of configured remotes with archiving
 - name: Look at current psconfig remote list with configured archives
   tags: [ 'ps::config' ]
   shell: psconfig remote list | tail -n +2 | jq -r '.[] | select(."configure-archives"==true) | .url'
   register: psconfig_remotes_archives
   changed_when: False
 
+# The 2 lists are used in psconfig_remotes.yml
 - name: add/delete remote mesh configurations that have a valid URL and state
   tags: [ 'ps::config' ]
   include_tasks: psconfig_remotes.yml

--- a/tasks/psconfig_remotes.yml
+++ b/tasks/psconfig_remotes.yml
@@ -5,9 +5,13 @@
 # item.state should be 'absent' or 'present'
 # item.configure_archives should be 'True' or 'False'
 #
+# psconfig_remotes and psconfig_remotes_archives should be defined
+# (see main.yml how they get populated)
+#
 # If we need to add much more psconfig functionality, we might consider
 # writing an Ansible module.
 
+# Try to delete only if already present
 - name: psconfig remote delete {{ item.url }}
   tags: [ 'ps::config' ]
   command: psconfig remote delete {{ item.url }}
@@ -15,6 +19,7 @@
     - item.state | default('present') == 'absent'
     - item.url in psconfig_remotes.stdout_lines
 
+# Delete a remote when existing with "configure-archives" and we want it without
 - name: psconfig remote delete {{ item.url }}
   tags: [ 'ps::config' ]
   command: psconfig remote delete {{ item.url }}
@@ -23,6 +28,7 @@
     - item.configure_archives | default('False') != True
     - item.url in psconfig_remotes_archives.stdout_lines
 
+# Adding only if not already present
 - name: psconfig remote add {{ item.url }}
   tags: [ 'ps::config' ]
   command: psconfig remote add {{ item.url }}
@@ -31,6 +37,7 @@
     - item.configure_archives | default('False') != True
     - item.url not in psconfig_remotes.stdout_lines
 
+# Adding only if not already present with "configure-archives" set
 - name: psconfig remote add --configure-archives {{ item.url }}
   tags: [ 'ps::config' ]
   command: psconfig remote add --configure-archives {{ item.url }}

--- a/tasks/psconfig_remotes.yml
+++ b/tasks/psconfig_remotes.yml
@@ -11,7 +11,17 @@
 - name: psconfig remote delete {{ item.url }}
   tags: [ 'ps::config' ]
   command: psconfig remote delete {{ item.url }}
-  when: item.state | default('present') == 'absent'
+  when:
+    - item.state | default('present') == 'absent'
+    - item.url in psconfig_remotes.stdout_lines
+
+- name: psconfig remote delete {{ item.url }}
+  tags: [ 'ps::config' ]
+  command: psconfig remote delete {{ item.url }}
+  when:
+    - item.state | default('present') == 'present'
+    - item.configure_archives | default('False') != True
+    - item.url in psconfig_remotes_archives.stdout_lines
 
 - name: psconfig remote add {{ item.url }}
   tags: [ 'ps::config' ]
@@ -19,6 +29,7 @@
   when:
     - item.state | default('present') == 'present'
     - item.configure_archives | default('False') != True
+    - item.url not in psconfig_remotes.stdout_lines
 
 - name: psconfig remote add --configure-archives {{ item.url }}
   tags: [ 'ps::config' ]
@@ -26,3 +37,4 @@
   when:
     - item.state | default('present') == 'present'
     - item.configure_archives | default('False') == True
+    - item.url not in psconfig_remotes_archives.stdout_lines


### PR DESCRIPTION
If a psconfig remote is already configured on the host, we will not touch it. Similarily if it is not present, we will not try to delete it.  This avoid putting additional load on the pS node.